### PR TITLE
Add __PIO_DONT_SET_CLOCK_SOURCE__ option

### DIFF
--- a/gd32/cmsis/variants/gd32a50x/system_gd32a50x.c
+++ b/gd32/cmsis/variants/gd32a50x/system_gd32a50x.c
@@ -45,7 +45,9 @@
 //#define __SYSTEM_CLOCK_24M_PLL_HXTAL                    (uint32_t)(24000000)
 //#define __SYSTEM_CLOCK_48M_PLL_HXTAL                    (uint32_t)(48000000)
 //#define __SYSTEM_CLOCK_72M_PLL_HXTAL                    (uint32_t)(72000000)
+#if !defined(__PIO_DONT_SET_CLOCK_SOURCE__) // make this the default unless we tell it not to in the build settings
 #define __SYSTEM_CLOCK_100M_PLL_HXTAL                   (uint32_t)(100000000)
+#endif
 
 #define RCU_MODIFY_DE_3(__delay)  do{                                     \
                                       volatile uint32_t i,reg;            \

--- a/gd32/cmsis/variants/gd32c10x/system_gd32c10x.c
+++ b/gd32/cmsis/variants/gd32c10x/system_gd32c10x.c
@@ -56,7 +56,9 @@ OF SUCH DAMAGE.
 //#define __SYSTEM_CLOCK_48M_PLL_HXTAL            (uint32_t)(48000000)
 //#define __SYSTEM_CLOCK_72M_PLL_HXTAL            (uint32_t)(72000000)
 //#define __SYSTEM_CLOCK_108M_PLL_HXTAL           (uint32_t)(108000000)
+#if !defined(__PIO_DONT_SET_CLOCK_SOURCE__) // make this the default unless we tell it not to in the build settings
 #define __SYSTEM_CLOCK_120M_PLL_HXTAL           (uint32_t)(120000000)
+#endif
 
 #define SEL_IRC8M       0x00U
 #define SEL_HXTAL       0x01U

--- a/gd32/cmsis/variants/gd32e23x/system_gd32e23x.c
+++ b/gd32/cmsis/variants/gd32e23x/system_gd32e23x.c
@@ -45,7 +45,9 @@
 /* select a system clock by uncommenting the following line */
 //#define __SYSTEM_CLOCK_8M_HXTAL              (__HXTAL)
 //#define __SYSTEM_CLOCK_8M_IRC8M              (__IRC8M)
+#if !defined(__PIO_DONT_SET_CLOCK_SOURCE__) // make this the default unless we tell it not to in the build settings
 #define __SYSTEM_CLOCK_72M_PLL_HXTAL         (uint32_t)(72000000)
+#endif
 //#define __SYSTEM_CLOCK_72M_PLL_IRC8M_DIV2    (uint32_t)(72000000)
 
 #define SEL_IRC8M       0x00

--- a/gd32/cmsis/variants/gd32e50x/system_gd32e50x.c
+++ b/gd32/cmsis/variants/gd32e50x/system_gd32e50x.c
@@ -55,8 +55,9 @@
 //#define __SYSTEM_CLOCK_72M_PLL_HXTAL            (uint32_t)(72000000)
 //#define __SYSTEM_CLOCK_120M_PLL_HXTAL           (uint32_t)(120000000)
 //#define __SYSTEM_CLOCK_168M_PLL_HXTAL           (uint32_t)(168000000)
+#if !defined(__PIO_DONT_SET_CLOCK_SOURCE__) // make this the default unless we tell it not to in the build settings
 #define __SYSTEM_CLOCK_180M_PLL_HXTAL           (uint32_t)(180000000)
-
+#endif
 
 #define SEL_IRC8M       0x00
 #define SEL_HXTAL       0x01

--- a/gd32/cmsis/variants/gd32f10x/system_gd32f10x.c
+++ b/gd32/cmsis/variants/gd32f10x/system_gd32f10x.c
@@ -60,7 +60,9 @@ OF SUCH DAMAGE.
 //#define __SYSTEM_CLOCK_56M_PLL_HXTAL            (uint32_t)(56000000)
 //#define __SYSTEM_CLOCK_72M_PLL_HXTAL            (uint32_t)(72000000)
 //#define __SYSTEM_CLOCK_96M_PLL_HXTAL            (uint32_t)(96000000)
+#if !defined(__PIO_DONT_SET_CLOCK_SOURCE__) // make this the default unless we tell it not to in the build settings
 #define __SYSTEM_CLOCK_108M_PLL_HXTAL           (uint32_t)(108000000)
+#endif
 
 #define RCU_MODIFY(__delay)     do{                                     \
                                     volatile uint32_t i;                \

--- a/gd32/cmsis/variants/gd32f1x0/system_gd32f1x0.c
+++ b/gd32/cmsis/variants/gd32f1x0/system_gd32f1x0.c
@@ -45,7 +45,9 @@
 /* select a system clock by uncommenting the following line */
 //#define __SYSTEM_CLOCK_8M_HXTAL              (__HXTAL)
 //#define __SYSTEM_CLOCK_8M_IRC8M              (__IRC8M)
+#if !defined(__PIO_DONT_SET_CLOCK_SOURCE__) // make this the default unless we tell it not to in the build settings
 #define __SYSTEM_CLOCK_72M_PLL_HXTAL         (uint32_t)(72000000)
+#endif
 //#define __SYSTEM_CLOCK_72M_PLL_IRC8M_DIV2    (uint32_t)(72000000)
 
 #define SEL_IRC8M       0x00

--- a/gd32/cmsis/variants/gd32f20x/system_gd32f20x.c
+++ b/gd32/cmsis/variants/gd32f20x/system_gd32f20x.c
@@ -57,7 +57,9 @@
 //#define __SYSTEM_CLOCK_72M_PLL_HXTAL            (uint32_t)(72000000)
 //#define __SYSTEM_CLOCK_96M_PLL_HXTAL            (uint32_t)(96000000)
 //#define __SYSTEM_CLOCK_108M_PLL_HXTAL           (uint32_t)(108000000)
+#if !defined(__PIO_DONT_SET_CLOCK_SOURCE__) // make this the default unless we tell it not to in the build settings
 #define __SYSTEM_CLOCK_120M_PLL_HXTAL           (uint32_t)(120000000)
+#endif
 
 
 #define SEL_IRC8M       0x00U

--- a/gd32/cmsis/variants/gd32f30x/system_gd32f30x.c
+++ b/gd32/cmsis/variants/gd32f30x/system_gd32f30x.c
@@ -52,7 +52,9 @@
 //#define __SYSTEM_CLOCK_48M_PLL_HXTAL            (uint32_t)(48000000)
 //#define __SYSTEM_CLOCK_72M_PLL_HXTAL            (uint32_t)(72000000)
 //#define __SYSTEM_CLOCK_108M_PLL_HXTAL           (uint32_t)(108000000)
+#if !defined(__PIO_DONT_SET_CLOCK_SOURCE__) // make this the default unless we tell it not to in the build settings
 #define __SYSTEM_CLOCK_120M_PLL_HXTAL           (uint32_t)(120000000)
+#endif
 
 #define SEL_IRC8M       0x00U
 #define SEL_HXTAL       0x01U

--- a/gd32/cmsis/variants/gd32f3x0/system_gd32f3x0.c
+++ b/gd32/cmsis/variants/gd32f3x0/system_gd32f3x0.c
@@ -48,7 +48,9 @@
 #if defined (GD32F310)
 //#define __SYSTEM_CLOCK_8M_HXTAL              (__HXTAL)
 //#define __SYSTEM_CLOCK_8M_IRC8M              (__IRC8M)
+#if !defined(__PIO_DONT_SET_CLOCK_SOURCE__) // make this the default unless we tell it not to in the build settings
 #define __SYSTEM_CLOCK_72M_PLL_HXTAL         (uint32_t)(72000000)
+#endif
 //#define __SYSTEM_CLOCK_72M_PLL_IRC8M_DIV2    (uint32_t)(72000000)
 //#define __SYSTEM_CLOCK_72M_PLL_IRC48M_DIV2     (uint32_t)(72000000)
 #endif /* GD32F310 */
@@ -59,7 +61,9 @@
 //#define __SYSTEM_CLOCK_72M_PLL_HXTAL         (uint32_t)(72000000)
 //#define __SYSTEM_CLOCK_72M_PLL_IRC8M_DIV2    (uint32_t)(72000000)
 //#define __SYSTEM_CLOCK_72M_PLL_IRC48M_DIV2     (uint32_t)(72000000)
+#if !defined(__PIO_DONT_SET_CLOCK_SOURCE__) // make this the default unless we tell it not to in the build settings
 #define __SYSTEM_CLOCK_84M_PLL_HXTAL           (uint32_t)(84000000)
+#endif
 //#define __SYSTEM_CLOCK_84M_PLL_IRC8M_DIV2    (uint32_t)(84000000)
 #endif /* GD32F330 */
 
@@ -73,7 +77,9 @@
 //#define __SYSTEM_CLOCK_96M_PLL_HXTAL         (uint32_t)(96000000)
 //#define __SYSTEM_CLOCK_96M_PLL_IRC8M_DIV2      (uint32_t)(96000000)
 //#define __SYSTEM_CLOCK_96M_PLL_IRC48M_DIV2     (uint32_t)(96000000)
+#if !defined(__PIO_DONT_SET_CLOCK_SOURCE__) // make this the default unless we tell it not to in the build settings
 #define __SYSTEM_CLOCK_108M_PLL_HXTAL        (uint32_t)(108000000)
+#endif
 //#define __SYSTEM_CLOCK_108M_PLL_IRC8M_DIV2   (uint32_t)(108000000)
 #endif /* GD32F350 */
 

--- a/gd32/cmsis/variants/gd32f403/system_gd32f403.c
+++ b/gd32/cmsis/variants/gd32f403/system_gd32f403.c
@@ -58,8 +58,9 @@
 //#define __SYSTEM_CLOCK_72M_PLL_HXTAL            (uint32_t)(72000000)
 //#define __SYSTEM_CLOCK_108M_PLL_HXTAL           (uint32_t)(108000000)
 //#define __SYSTEM_CLOCK_120M_PLL_HXTAL           (uint32_t)(120000000)
+#if !defined(__PIO_DONT_SET_CLOCK_SOURCE__) // make this the default unless we tell it not to in the build settings
 #define __SYSTEM_CLOCK_168M_PLL_HXTAL           (uint32_t)(168000000)
-
+#endif
 
 #define SEL_IRC8M       0x00U
 #define SEL_HXTAL       0x01U

--- a/gd32/cmsis/variants/gd32f4xx/system_gd32f4xx.c
+++ b/gd32/cmsis/variants/gd32f4xx/system_gd32f4xx.c
@@ -51,7 +51,9 @@
 //#define __SYSTEM_CLOCK_168M_PLL_25M_HXTAL       (uint32_t)(168000000)
 //#define __SYSTEM_CLOCK_200M_PLL_IRC16M          (uint32_t)(200000000)
 //#define __SYSTEM_CLOCK_200M_PLL_8M_HXTAL        (uint32_t)(200000000)
+#if !defined(__PIO_DONT_SET_CLOCK_SOURCE__) // make this the default unless we tell it not to in the build settings
 #define __SYSTEM_CLOCK_200M_PLL_25M_HXTAL       (uint32_t)(200000000)
+#endif
 //#define __SYSTEM_CLOCK_240M_PLL_IRC16M          (uint32_t)(240000000)
 //#define __SYSTEM_CLOCK_240M_PLL_8M_HXTAL        (uint32_t)(240000000)
 //#define __SYSTEM_CLOCK_240M_PLL_25M_HXTAL       (uint32_t)(240000000)

--- a/gd32/cmsis/variants/gd32h7xx/system_gd32h7xx.c
+++ b/gd32/cmsis/variants/gd32h7xx/system_gd32h7xx.c
@@ -48,7 +48,9 @@
 //#define __SYSTEM_CLOCK_HXTAL                    (__HXTAL)
 //#define __SYSTEM_CLOCK_200M_PLL0_HXTAL          (uint32_t)(200000000)
 //#define __SYSTEM_CLOCK_400M_PLL0_HXTAL          (uint32_t)(400000000)
+#if !defined(__PIO_DONT_SET_CLOCK_SOURCE__) // make this the default unless we tell it not to in the build settings
 #define __SYSTEM_CLOCK_600M_PLL0_HXTAL          (uint32_t)(600000000)
+#endif
 
 /*
 Note: the power mode need to match the mcu selection and external power supply circuit.

--- a/gd32/cmsis/variants/gd32l23x/system_gd32l23x.c
+++ b/gd32/cmsis/variants/gd32l23x/system_gd32l23x.c
@@ -45,7 +45,9 @@
 /* select a system clock by uncommenting the following line */
 //#define __SYSTEM_CLOCK_8M_HXTAL              (__HXTAL)
 //#define __SYSTEM_CLOCK_16M_IRC16M            (__IRC16M)
+#if !defined(__PIO_DONT_SET_CLOCK_SOURCE__) // make this the default unless we tell it not to in the build settings
 #define __SYSTEM_CLOCK_64M_PLL_HXTAL         (uint32_t)(64000000)
+#endif
 //#define __SYSTEM_CLOCK_64M_PLL_IRC16M        (uint32_t)(64000000)
 
 #define SEL_IRC16M      0x00

--- a/gd32/cmsis/variants/gd32vw55x/system_gd32vw55x.c
+++ b/gd32/cmsis/variants/gd32vw55x/system_gd32vw55x.c
@@ -41,7 +41,9 @@
 //#define __SYSTEM_CLOCK_48M_PLLDIG_IRC16M             (uint32_t)(48000000)
 //#define __SYSTEM_CLOCK_160M_PLLDIG_IRC16M             (uint32_t)(160000000)
 //#define __SYSTEM_CLOCK_48M_PLLDIG_HXTAL              (uint32_t)(48000000)
+#if !defined(__PIO_DONT_SET_CLOCK_SOURCE__) // make this the default unless we tell it not to in the build settings
 #define __SYSTEM_CLOCK_160M_PLLDIG_HXTAL              (uint32_t)(160000000)
+#endif
 
 #define HXTALSTB_DELAY     {                                  \
                               volatile uint32_t i;           \

--- a/gd32/cmsis/variants/gd32w51x/system_gd32w51x.c
+++ b/gd32/cmsis/variants/gd32w51x/system_gd32w51x.c
@@ -56,7 +56,9 @@
 //#define __SYSTEM_CLOCK_168M_PLLP_40M_HXTAL          (uint32_t)(168000000)
 //#define __SYSTEM_CLOCK_180M_PLLP_IRC16M             (uint32_t)(180000000)
 //#define __SYSTEM_CLOCK_180M_PLLP_25M_HXTAL          (uint32_t)(180000000)
+#if !defined(__PIO_DONT_SET_CLOCK_SOURCE__) // make this the default unless we tell it not to in the build settings
 #define __SYSTEM_CLOCK_180M_PLLP_40M_HXTAL          (uint32_t)(180000000)
+#endif
 
 #define HXTALSTB_DELAY     {                                 \
                               volatile uint32_t i;           \


### PR DESCRIPTION
Introduce a `__PIO_DONT_SET_CLOCK_SOURCE__` macro to allow users to override the default clock-source selection without touching the SPL library itself.

Fixes https://github.com/CommunityGD32Cores/gd32-pio-spl-package/issues/4

Copied from https://github.com/CommunityGD32Cores/ArduinoCore-GD32/commit/86e0ac7f8bb4c7f53654bb341eb19b303e8025e0
